### PR TITLE
fix(nanocoder): show complete Homebrew install flow

### DIFF
--- a/pages/nanocoder.tsx
+++ b/pages/nanocoder.tsx
@@ -122,7 +122,11 @@ const reasons: Reason[] = [
 
 const installCommands: InstallCommand[] = [
   { label: "NPM", command: "npm install -g @nanocollective/nanocoder" },
-  { label: "Homebrew", command: "brew install nanocoder" },
+  {
+    label: "Homebrew",
+    command: `brew tap nano-collective/nanocoder https://github.com/Nano-Collective/nanocoder
+brew install nano-collective/nanocoder/nanocoder`,
+  },
   {
     label: "Nix Flakes",
     command: "nix run github:Nano-Collective/nanocoder",


### PR DESCRIPTION
### Description

**What does this PR do?**

Fix the incomplete Homebrew command on the Nanocoder landing page. The formula lives in a custom tap, so the bare core-formula command fails before downloading Nanocoder.

**Changes made:**

- add the explicit custom-tap URL before installation
- install the fully-qualified formula, which is compatible with current Homebrew tap trust

### Verification

- reproduced `brew install nanocoder` twice in clean Linuxbrew: `No available formula ... Did you mean nanorc?`
- completed an end-to-end test in a standard Linuxbrew Docker environment: the corrected commands installed Nanocoder and `nanocoder --version` returned `1.28.1`
- `pnpm run types`
- `pnpm run lint`
- `pnpm run build` (successful; external stats/feed fetches emitted non-fatal timeout/rate-limit warnings)

Fixes Nano-Collective/nanocoder#650
